### PR TITLE
Desactivar vendedor obligatorio según configuración y mejoras SonarQube

### DIFF
--- a/pos_orderline_salesperson/__manifest__.py
+++ b/pos_orderline_salesperson/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'POS Orderline Salesperson',
-    'version': '13.1.2.0',
+    'version': '13.0.1.2.1',
     'summary': 'POS Orderline Salesperson',
     'category': 'Sales/Point Of Sale',
     'author': 'Zeinab Abdelmonem, Ingenioso CO',

--- a/pos_orderline_salesperson/models/pos_config.py
+++ b/pos_orderline_salesperson/models/pos_config.py
@@ -2,6 +2,7 @@
 
 from odoo import fields, models
 
+
 class PosConfig(models.Model):
     _inherit = 'pos.config'
 

--- a/pos_orderline_salesperson/models/pos_config.py
+++ b/pos_orderline_salesperson/models/pos_config.py
@@ -1,14 +1,28 @@
 # -*- coding: utf-8 -*-
 
-from odoo import fields, models
+from odoo import fields, models, api
 
 
 class PosConfig(models.Model):
     _inherit = 'pos.config'
 
-    allow_orderline_user = fields.Boolean(string='Allow Orderline Salesperson', help='Allow custom salesperson on Orderlines')
+    allow_orderline_user = fields.Boolean(
+        string='Allow Orderline Salesperson', 
+        help='Allow custom salesperson on Orderlines'
+    )
     employee_salesperson_ids = fields.Many2many(
-        'hr.employee', "hr_employee_salesperson" ,string="Employees with access",
-        help='If left empty, all employees can log in to the PoS session')
+        'hr.employee', "hr_employee_salesperson",
+        string="Employees with access",
+        help='If left empty, all employees can log in to the PoS session'
+    )
 
-    mandatory_salesperson = fields.Boolean("Mandatory", default=True, help="Enable mandatory salesperson.")
+    mandatory_salesperson = fields.Boolean(
+        "Mandatory",
+        default=True,
+        help="Enable mandatory salesperson."
+    )
+
+    @api.onchange('allow_orderline_user')
+    def _onchange_allow_orderline_user(self):
+        if not self.allow_orderline_user:
+            self.mandatory_salesperson = False

--- a/pos_orderline_salesperson/models/pos_order.py
+++ b/pos_orderline_salesperson/models/pos_order.py
@@ -2,6 +2,7 @@
 
 from odoo import api, fields, models
 
+
 class PosOrder(models.Model):
 	_inherit = "pos.order"
 
@@ -11,8 +12,7 @@ class PosOrder(models.Model):
 	def _compute_commission_total(self):
 		for record in self:
 			record.commission_total = sum(record.mapped("lines.agent_ids.amount"))
-			pass
-		
+					
 	commission_total = fields.Float(
 		string="Total Commission", compute="_compute_commission_total", store=True,
 	)
@@ -20,26 +20,6 @@ class PosOrder(models.Model):
 	def recompute_lines_agents(self):
 		self.mapped("lines").recompute_agents()
 
-	# def _process_payment_lines(self, pos_order, order, pos_session, draft):
-	# 	for line in pos_order["lines"]:
-	# 		employee_id = line[2]["salesperson_id"]		
-	# 		employee = self.env["hr.employee"].search(
-    #             [
-    #                 ("id", "=", employee_id)
-	# 			]
-	# 		)
-	# 		employee['agent_id']
-
-	# 	result = super()._process_payment_lines(pos_order, order, pos_session, draft)
-	# 	return result
-
-	# def _prepare_invoice_line(self, order_line):
-	# 	vals = super()._prepare_invoice_line(order_line)
-	# 	vals["agent_ids"] = [
-	# 		(0, 0, {"agent_id": x.agent_id.id, "commission_id": x.commission_id.id})
-	# 		for x in order_line.agent_ids
-	# 	]
-	# 	return vals
 
 class PosOrderLine(models.Model):
 	_inherit = [
@@ -63,7 +43,6 @@ class PosOrderLine(models.Model):
 		
 		if line and 'salesperson_id' in line[2]:
 			employee_id = line[2]["salesperson_id"]
-			#employee = self.env["hr.employee"].browse(employee_id)
 			employee = self.env["hr.employee"].search([("id", "=", employee_id)])
 			agent_id_list = employee['agent_id']
 			for agent in agent_id_list:

--- a/pos_orderline_salesperson/static/src/js/models.js
+++ b/pos_orderline_salesperson/static/src/js/models.js
@@ -1,8 +1,8 @@
 odoo.define('pos_orderline_selesperson.employees_salesperson', function (require) {
     "use strict";
 
-var models = require('point_of_sale.models');
-var rpc = require('web.rpc');
+const models = require('point_of_sale.models');
+
 
 models.load_models([{
     model:  'hr.employee',

--- a/pos_orderline_salesperson/static/src/js/payment_screen.js
+++ b/pos_orderline_salesperson/static/src/js/payment_screen.js
@@ -1,18 +1,18 @@
 odoo.define('point_of_sale_screens', function (require) {
     "use strict";
 
-    var screens = require('point_of_sale.screens');
-    var core = require('web.core');
-    var utils = require('web.utils');
+    const screens = require('point_of_sale.screens');
+    const core = require('web.core');
+    
 
-    var _t = core._t;
+    const _t = core._t;
 
     screens.PaymentScreenWidget.include({
 
         order_is_valid_salesperson: function () {
-            var self = this;
-            var order = this.pos.get_order();
-            var exist_order_without_salesperson = order.get_orderlines().filter((item)=>{
+            const self = this;
+            const order = this.pos.get_order();
+            const exist_order_without_salesperson = order.get_orderlines().filter((item)=>{
                 return !Boolean(item.get_salesperson());
             })
             

--- a/pos_orderline_salesperson/static/src/js/salesperson.js
+++ b/pos_orderline_salesperson/static/src/js/salesperson.js
@@ -1,13 +1,13 @@
 odoo.define('pos_orderline_salesperson.salesperson', function (require) {
 "use strict";
 
-    var models = require('point_of_sale.models');
-    var screens = require('point_of_sale.screens');
-    var core = require('web.core');
-    var QWeb = core.qweb;
-    var _t   = core._t;
+    const models = require('point_of_sale.models');
+    const screens = require('point_of_sale.screens');
+    const core = require('web.core');
+    
+    const _t = core._t;
 
-    var _super_orderline = models.Orderline.prototype;
+    const _super_orderline = models.Orderline.prototype;
 
     models.Orderline = models.Orderline.extend({
         initialize: function(attr, options) {
@@ -36,13 +36,13 @@ odoo.define('pos_orderline_salesperson.salesperson', function (require) {
             }
         },
         clone: function(){
-            var orderline = _super_orderline.clone.call(this);
+            const orderline = _super_orderline.clone.call(this);
             orderline.salesperson = this.salesperson;
             orderline.salesperson_id = this.salesperson_id;
             return orderline;
         },
         export_as_JSON: function(){
-            var json = _super_orderline.export_as_JSON.call(this);
+            const json = _super_orderline.export_as_JSON.call(this);
             json.salesperson = this.salesperson;
             json.salesperson_id = this.salesperson_id;
             return json;
@@ -56,14 +56,14 @@ odoo.define('pos_orderline_salesperson.salesperson', function (require) {
 
     screens.OrderWidget.include({
         render_orderline: function(orderline) {
-            var node = this._super(orderline);
-            var salesperson_icon = node.querySelector('.line-salesperson-icon');
+            const node = this._super(orderline);
+            const salesperson_icon = node.querySelector('.line-salesperson-icon');
             if(salesperson_icon){
                 salesperson_icon.addEventListener('click', (function() {
                     this.show_salesperson_popup(orderline);
                 }.bind(this)));
             }
-            var remove_salesperson = node.querySelector('.line-remove-salesperson');
+            const remove_salesperson = node.querySelector('.line-remove-salesperson');
             if(remove_salesperson){
                 remove_salesperson.addEventListener('click', (function() {
                     orderline.remove_salesperson();
@@ -72,7 +72,7 @@ odoo.define('pos_orderline_salesperson.salesperson', function (require) {
             return node;
         },
         show_salesperson_popup: function(orderline){
-            var self = this;
+            const self = this;
             this.pos.gui.show_popup('salespersonpopup',{
                 title: _t('Select Salesperson'),
                 salespersons: self.pos.employees_salesperson,
@@ -82,10 +82,10 @@ odoo.define('pos_orderline_salesperson.salesperson', function (require) {
         },
     });
 
-    var OrderlineSalespersonButton = screens.ActionButtonWidget.extend({
+    const OrderlineSalespersonButton = screens.ActionButtonWidget.extend({
         template: 'OrderlineSalespersonButton',
         button_click: function(){
-            var self = this;
+            const self = this;
             this.pos.gui.show_popup('salespersonpopup',{
                 title: _t('Select Salesperson'),
                 salespersons: self.pos.employees_salesperson,

--- a/pos_orderline_salesperson/static/src/js/salesperson_popup.js
+++ b/pos_orderline_salesperson/static/src/js/salesperson_popup.js
@@ -1,20 +1,20 @@
 odoo.define('pos_orderline_salesperson.salesperson_popup', function (require) {
 "use strict";
 
-    var gui = require('point_of_sale.gui');
-    var PopupWidget = require('point_of_sale.popups');
-    var core = require('web.core');
-    var QWeb = core.qweb;
-    var _t   = core._t;
+    const gui = require('point_of_sale.gui');
+    const PopupWidget = require('point_of_sale.popups');
+    const core = require('web.core');
+    
+   
 
-    var SalesPersonPopupWidget = PopupWidget.extend({
+    const SalesPersonPopupWidget = PopupWidget.extend({
         template: 'SalesPersonPopupWidget',
 
         show: function(options){
             this._super(options);
             this.$('.salesperson-selected').click(function(){
-                var order = options.pos.get_order();
-                var self = this;
+                const order = options.pos.get_order();
+                const self = this;
                 //var salesperson = $(this).data('value');
                 /* si no se selecciono desde na linea de venta, es para toda la orden */
                 if (!options.orderline) {


### PR DESCRIPTION
Se desactiva automáticamente el campo “Vendedor obligatorio” cuando la opción
“Permitir vendedor en líneas de pedido” está deshabilitada.

Se aplican mejoras sugeridas por SonarQube para:
Optimizar la legibilidad del código.
Reducir duplicación.
Mejorar la mantenibilidad general del módulo.